### PR TITLE
Reduce section vertical padding on static pages

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 export const About: React.FC = () => {
   return (
     <div className="bg-surface min-h-screen">
-      <section className="py-32 pt-40">
+      <section className="py-8">
         <div className="max-w-4xl mx-auto px-6 md:px-8">
           <Link
             to="/"

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 export const Privacy: React.FC = () => {
   return (
     <div className="bg-surface min-h-screen">
-      <section className="py-32 pt-40">
+      <section className="py-8">
         <div className="max-w-4xl mx-auto px-6 md:px-8">
           <Link
             to="/"

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 export const Terms: React.FC = () => {
   return (
     <div className="bg-surface min-h-screen">
-      <section className="py-32 pt-40">
+      <section className="py-8">
         <div className="max-w-4xl mx-auto px-6 md:px-8">
           <Link
             to="/"


### PR DESCRIPTION
Tighten vertical spacing on About, Privacy, and Terms pages by replacing `py-32 pt-40` with `py-8`. This reduces excessive top/bottom whitespace and improves the layout, especially on smaller screens. Files updated: src/pages/About.tsx, src/pages/Privacy.tsx, src/pages/Terms.tsx.